### PR TITLE
Fixed issues with custom textures not loading on Unix-based systems

### DIFF
--- a/BopCustomTextures/BopCustomTextures.csproj
+++ b/BopCustomTextures/BopCustomTextures.csproj
@@ -39,7 +39,7 @@
 		<Compile Include="src\**\*.cs" />
 	</ItemGroup>
 
-	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
-	  <Exec Command="call postbuild.bat $(TargetPath)" />
+	<Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="$(PostBuildCopyDestination) != ''">
+	  <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(PostBuildCopyDestination)" />
 	</Target>
 </Project>

--- a/BopCustomTextures/src/Customs/CustomSceneManager.cs
+++ b/BopCustomTextures/src/Customs/CustomSceneManager.cs
@@ -16,7 +16,7 @@ public class CustomSceneManager(ILogger logger) : BaseCustomManager(logger)
 {
     public CustomJsonInitializer jsonInitializer = new CustomJsonInitializer(logger);
     public readonly Dictionary<SceneKey, JObject> CustomScenes = [];
-    public static readonly Regex PathRegex = new Regex(@"\\(?:level|scene)s?$", RegexOptions.IgnoreCase);
+    public static readonly Regex PathRegex = new Regex(@"[\\/](?:level|scene)s?$", RegexOptions.IgnoreCase);
     public static readonly Regex FileRegex = new Regex(@"(\w+).json$", RegexOptions.IgnoreCase);
 
     public static bool IsCustomSceneDirectory(string path)

--- a/BopCustomTextures/src/Customs/CustomTextureManager.cs
+++ b/BopCustomTextures/src/Customs/CustomTextureManager.cs
@@ -23,8 +23,8 @@ public class CustomTextureManager(ILogger logger) : BaseCustomManager(logger)
     public readonly Dictionary<Texture2D, Dictionary<string, Sprite>> SpriteMaps = [];
     public readonly HashSet<Sprite> CustomSprites = [];
     public readonly Dictionary<Texture2D, (SceneKey, int)> TextureMaps = [];
-    public static readonly Regex PathRegex = new Regex(@"\\text?u?r?e?s?$", RegexOptions.IgnoreCase);
-    public static readonly Regex FileRegex = new Regex(@"^text?u?r?e?s?\\(\w+)\\.*?([^\\]*\.(?:png|j(?:pe?g|pe|f?if|fi)))$", RegexOptions.IgnoreCase);
+    public static readonly Regex PathRegex = new Regex(@"[\\/]text?u?r?e?s?$", RegexOptions.IgnoreCase);
+    public static readonly Regex FileRegex = new Regex(@"^text?u?r?e?s?[\\/](\w+)[\\/].*?([^\\/]*\.(?:png|j(?:pe?g|pe|f?if|fi)))$", RegexOptions.IgnoreCase);
     public static readonly Regex FileRegexAtlas = new Regex(@"^sactx-(\d+)", RegexOptions.IgnoreCase);
     public static readonly Regex FileRegexSeperate = new Regex(@"^(\w+)");
     public static readonly Regex SceneAndSpriteAtlasIndexRegex = new Regex(@"^sactx-(\d+)-\d+x\d+-DXT5\|BC3-_(\w+)Atlas");

--- a/README.md
+++ b/README.md
@@ -175,6 +175,14 @@ After running Bits & Bops with the latest version of this plugin installed, a co
        - Set build mode to "release".
        - Build project.
 4. Copy ``BopCustomTextures/BopCustomTextures/bin/Release/net472/BopCustomTextures.dll`` into ``<Bits & Bops Installation>/BepinEx/plugins/``.
+    - You can setup `BopCustomTextures.csproj.user` file next to `BopCustomTextures.csproj` with the `PostBuildCopyDestination` path set to automatically copy the new DLL after build:
+      ```xml
+      <Project>
+        <PropertyGroup>
+          <PostBuildCopyDestination>&lt;Bits &amp; Bops Installation&gt;/BepInEx/plugins</PostBuildCopyDestination>
+        </PropertyGroup>
+      </Project>
+      ```
 
 ## Implementation
 ### Custom Textures


### PR DESCRIPTION
Fixed path regex to correctly detect Unit-styled paths in addition to Windows ones.

Also replaced Windows postbuild.bat script with MSBuiltTools approach.